### PR TITLE
The `validateMessage` param in the `send` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (authKey, senderId, route) {
 
         mobileNos = validateMobileNos(mobileNos);
 
-        message = validateMessage(validateMessage);
+        message = validateMessage(message);
 
         var isUnicode = isUnicodeString(message);
 


### PR DESCRIPTION
The problem is that the code passes the `validateMessage` function as a param to the `validateMessage` function, then the `validateMessage` returns the "message" as it now the `validateMessage` function and not the `message` string

This will fix #1 issue
